### PR TITLE
do not rely on rename

### DIFF
--- a/packages/openapi_freezed_dio_builder/build.yaml
+++ b/packages/openapi_freezed_dio_builder/build.yaml
@@ -2,8 +2,8 @@ builders:
   openapi_freezed_dio_builder:
     import: 'package:openapi_freezed_dio_builder/openapi_freezed_dio_builder.dart'
     builder_factories: ['openapiCodeBuilder']
-    build_extensions: {".openapi.yaml": [".openapi.dart"]}
-    auto_apply: dependents
-#    build_to: cache
+    build_extensions: { '.openapi.yaml': ['.openapi.dart'] }
+    auto_apply: all_packages
     build_to: source
-    runs_before: ['json_serializable|json_serializable']
+    applies_builders: ['freezed', json_serializable]
+    runs_before: ['freezed', 'json_serializable']

--- a/packages/openapi_freezed_dio_builder/lib/src/openapi_code_builder.dart
+++ b/packages/openapi_freezed_dio_builder/lib/src/openapi_code_builder.dart
@@ -847,8 +847,8 @@ class OpenApiCodeBuilder extends Builder {
     final l = OpenApiLibraryGenerator(
       api,
       baseName,
-      AssetId(outputId.package, outputId.path.replaceAll('.openapi', '')).changeExtension('.g.dart').pathSegments.last,
-      AssetId(outputId.package, outputId.path.replaceAll('.openapi', ''))
+      AssetId(outputId.package, outputId.path).changeExtension('.g.dart').pathSegments.last,
+      AssetId(outputId.package, outputId.path)
           .changeExtension('.freezed.dart')
           .pathSegments
           .last,
@@ -864,10 +864,10 @@ class OpenApiCodeBuilder extends Builder {
 //    print(DartFormatter().format('${l.accept(emitter)}'));
     //print('inputId: $inputId / outputId: $outputId');
     await buildStep.writeAsString(outputId, libraryOutput);
-    Future<void>.delayed(Duration(seconds: 1)).then((_) {
-      // no idea what I'm doing
-      File(outputId.path).rename(outputId.path.replaceAll('openapi.', ''));
-    });
+    // Future<void>.delayed(Duration(seconds: 1)).then((_) {
+    //   // no idea what I'm doing
+    //   File(outputId.path).rename(outputId.path.replaceAll('openapi.', ''));
+    // });
   }
 
   @override


### PR DESCRIPTION
Do not rely on renaming the output artifact (to my knowledge this is anyhow not supported by _build_runner_).
Instead do the following:
- process the file as indicated by `buildExtensions()` from `xxx.openapi.yaml` to `xxx.openapi.dart`
- change `build.yaml` so that the _@freezed_ annotation gets processed subsequently

Potential fix for #2.