### PR TITLE
fix: The URL parameters with underscores cannot be correctly convert

### DIFF
--- a/packages/openapi_freezed_dio_builder/lib/src/openapi_code_builder.dart
+++ b/packages/openapi_freezed_dio_builder/lib/src/openapi_code_builder.dart
@@ -18,13 +18,14 @@ import 'package:yaml/yaml.dart';
 final _logger = Logger('openapi_code_builder');
 
 class OpenApiLibraryGenerator {
-  OpenApiLibraryGenerator(this.api,
-      this.baseName,
-      this.partFileName,
-      this.freezedPartFileName, {
-        this.useNullSafetySyntax = false,
-        this.apiMethodsWithRequest = false,
-      });
+  OpenApiLibraryGenerator(
+    this.api,
+    this.baseName,
+    this.partFileName,
+    this.freezedPartFileName, {
+    this.useNullSafetySyntax = false,
+    this.apiMethodsWithRequest = false,
+  });
 
   final APIDocument api;
 
@@ -35,21 +36,15 @@ class OpenApiLibraryGenerator {
   final bool useNullSafetySyntax;
   final bool apiMethodsWithRequest;
 
-  final jsonSerializable = refer(
-      'JsonSerializable', 'package:json_annotation/json_annotation.dart');
-  final freezed = refer(
-      'freezed', 'package:freezed_annotation/freezed_annotation.dart');
-  final jsonValue = refer(
-      'JsonValue', 'package:json_annotation/json_annotation.dart');
-  final jsonKey = refer(
-      'JsonKey', 'package:json_annotation/json_annotation.dart');
+  final jsonSerializable = refer('JsonSerializable', 'package:json_annotation/json_annotation.dart');
+  final freezed = refer('freezed', 'package:freezed_annotation/freezed_annotation.dart');
+  final jsonValue = refer('JsonValue', 'package:json_annotation/json_annotation.dart');
+  final jsonKey = refer('JsonKey', 'package:json_annotation/json_annotation.dart');
   final _dio = refer('Dio', 'package:dio/dio.dart');
   final _dioResponse = refer('Response', 'package:dio/dio.dart');
   final _apiUuid = refer('ApiUuid', './uuid.dart');
-  final _apiUuidNullJsonConverter = refer(
-      'ApiUuidNullJsonConverter', './uuid_converter.dart');
-  final _listApiUuidNullJsonConverter = refer(
-      'ListApiUuidNullJsonConverter', './uuid_converter.dart');
+  final _apiUuidNullJsonConverter = refer('ApiUuidNullJsonConverter', './uuid_converter.dart');
+  final _listApiUuidNullJsonConverter = refer('ListApiUuidNullJsonConverter', './uuid_converter.dart');
   final _required = refer('required', 'package:meta/meta.dart');
   final _override = refer('override');
   final _void = refer('void');
@@ -66,8 +61,7 @@ class OpenApiLibraryGenerator {
   final securitySchemes = <String, Expression>{};
 
   final lb = LibraryBuilder();
-  final securitySchemesClass = ClassBuilder()
-    ..name = 'SecuritySchemes';
+  final securitySchemesClass = ClassBuilder()..name = 'SecuritySchemes';
   final List<Expression?> routerConfig = <Expression>[];
 
   Library generate() {
@@ -87,40 +81,33 @@ class OpenApiLibraryGenerator {
     ];
 
     final grouped = api.paths!.entries.groupListsBy((element) =>
-        element.value!.operations.values.map((e) => e!.tags ?? []).expand((
-            element) => element).toSet().join());
-    final classes = grouped.entries.map((value) =>
-        Class((cb) {
+        element.value!.operations.values.map((e) => e!.tags ?? []).expand((element) => element).toSet().join());
+    final classes = grouped.entries.map((value) => Class((cb) {
           cb
             ..name = '${value.key.titleCase.replaceAll(' ', '')}Api'
             ..constructors.add(Constructor(
-                  (cb) =>
-              cb
-                ..requiredParameters.addAll(fields.map((f) =>
-                    Parameter((pb) =>
-                    pb
-                      ..name = f.key
-                      ..toThis = true))),
-            ))
-            ..fields.addAll(fields.map((f) =>
-                Field((fb) =>
-                fb
+              (cb) => cb
+                ..requiredParameters.addAll(fields.map((f) => Parameter((pb) => pb
                   ..name = f.key
-                  ..type = f.value
-                  ..modifier = FieldModifier.final$)));
+                  ..toThis = true))),
+            ))
+            ..fields.addAll(fields.map((f) => Field((fb) => fb
+              ..name = f.key
+              ..type = f.value
+              ..modifier = FieldModifier.final$)));
           //cb.name = baseName;
           cb.abstract = false;
           for (final path in value.value) {
             for (final operation in path.value!.operations.entries) {
               final pathName = path.key
                   .replaceAll(
-                // language=RegExp
-                  RegExp(r'[{}]'),
-                  '')
+                      // language=RegExp
+                      RegExp(r'[{}]'),
+                      '')
                   .camelCase;
               final operationName = operation.value!.id == null
                   ? '$pathName'
-                  '${operation.key.pascalCase}'
+                      '${operation.key.pascalCase}'
                   : operation.value!.id!.camelCase;
 
               final responseClass = ClassBuilder();
@@ -131,63 +118,45 @@ class OpenApiLibraryGenerator {
               Reference? successResponseBodyType;
               for (final response in operation.value!.responses!.entries) {
                 final clientResponseParseParams = <Expression>[];
-                final content = (response.value!.content ?? {})[mediaTypeJson
-                    .contentType];
+                final content = (response.value!.content ?? {})[mediaTypeJson.contentType];
 //              OpenApiContentType responseContentType;
                 Reference? bodyType;
                 if (content != null) {
                   if (content.schema!.type == APIType.array) {
                     bodyType = _referType('List', generics: [
-                      _schemaReference(content.schema!.items!.referenceURI!
-                          .pathSegments.last, content.schema!)
+                      _schemaReference(content.schema!.items!.referenceURI!.pathSegments.last, content.schema!)
                     ]);
                   } else {
-                    bodyType =
-                        _schemaReference(responseClass.name!, content.schema!);
+                    bodyType = _schemaReference(responseClass.name!, content.schema!);
                   }
 
                   clientResponseParseParams.add(bodyType
-                      .newInstanceNamed('fromJson', [refer('response')
-                      .property('responseBodyJson')([])
-                      .awaited
-                  ]));
+                      .newInstanceNamed('fromJson', [refer('response').property('responseBodyJson')([]).awaited]));
                 } else {
                   if (response.value!.content?.length == 1) {
-                    final responseContent = response.value!.content!.entries
-                        .first;
-                    bodyType = _toDartType(
-                        '${refer(responseClass.name!)}Content',
-                        responseContent.value!.schema!);
+                    final responseContent = response.value!.content!.entries.first;
+                    bodyType = _toDartType('${refer(responseClass.name!)}Content', responseContent.value!.schema!);
                     if (_typeString == bodyType) {
-                      clientResponseParseParams.add(refer('response')
-                          .property('responseBodyString')([])
-                          .awaited);
+                      clientResponseParseParams.add(refer('response').property('responseBodyString')([]).awaited);
                     } else if (_dioResponseBody == bodyType) {
-                      clientResponseParseParams.add(refer('response')
-                          .property('responseBodyBytes')([])
-                          .awaited);
+                      clientResponseParseParams.add(refer('response').property('responseBodyBytes')([]).awaited);
                     } else {
-                      throw StateError(
-                          'Unsupported bodyType $bodyType for responses.');
+                      throw StateError('Unsupported bodyType $bodyType for responses.');
                     }
                   }
                 }
-                if (response.key.startsWith('2') ||
-                    (response.key == 'default' &&
-                        successResponseBodyType == null)) {
+                if (response.key.startsWith('2') || (response.key == 'default' && successResponseBodyType == null)) {
                   successResponseBodyType = bodyType;
                 }
               }
 
-              final generics = [
-                _dioResponse.addGenerics(successResponseBodyType ?? _void)
-              ];
+              final generics = [_dioResponse.addGenerics(successResponseBodyType ?? _void)];
 
               //lb.body.add(responseClass.build());
               final clientMethod = MethodBuilder()
                 ..name = operationName
-                ..addDartDoc(operation.value!.summary)..addDartDoc(
-                    operation.value!.description)
+                ..addDartDoc(operation.value!.summary)
+                ..addDartDoc(operation.value!.description)
                 ..docs.add('/// ${operation.key}: ${path.key}')
                 ..docs.add('///')
                 ..returns = _referType('Future', generics: generics)
@@ -197,8 +166,8 @@ class OpenApiLibraryGenerator {
               Method((mb) {
                 mb
                   ..name = operationName
-                  ..addDartDoc(operation.value!.summary)..addDartDoc(
-                    operation.value!.description)
+                  ..addDartDoc(operation.value!.summary)
+                  ..addDartDoc(operation.value!.description)
                   ..docs.add('/// ${operation.key}: ${path.key}')
                   ..returns = _referType('Future', generics: generics);
 
@@ -206,48 +175,36 @@ class OpenApiLibraryGenerator {
                 final routerParamsNamed = <String, Expression>{};
 
                 if (apiMethodsWithRequest) {
-                  mb.requiredParameters.add(
-                      Parameter((pb) => pb..name = 'request'));
+                  mb.requiredParameters.add(Parameter((pb) => pb..name = 'request'));
                   routerParams.add(refer('request'));
                 }
 
                 // ignore: avoid_function_literals_in_foreach_calls
-                final allParameters = [
-                  ...?path.value!.parameters,
-                  ...?operation.value!.parameters
-                ];
+                final allParameters = [...?path.value!.parameters, ...?operation.value!.parameters];
                 for (final param in allParameters) {
                   final paramType = _toDartType(operationName, param!.schema!);
                   final paramNameCamelCase = param.name!.camelCase;
                   if (param.description != null) {
-                    clientMethod.docs.add(
-                        '/// * [$paramNameCamelCase]: ${param.description}');
+                    clientMethod.docs.add('/// * [$paramNameCamelCase]: ${param.description}');
                   }
-                  final p = Parameter((pb) =>
-                  pb
+                  final p = Parameter((pb) => pb
                     ..name = paramNameCamelCase
                     ..type = paramType.asNullable(!param.isRequired)
                     ..asRequired(this, param.isRequired)
                     ..named = true);
                   mb.optionalParameters.add(p);
                   clientMethod.optionalParameters.add(p);
-                  final decodeParameterFrom = (APIParameter param,
-                      Expression expression) {
-                    final schemaType = ArgumentError.checkNotNull(
-                        param.schema?.type, 'param.schema.type');
+                  final decodeParameterFrom = (APIParameter param, Expression expression) {
+                    final schemaType = ArgumentError.checkNotNull(param.schema?.type, 'param.schema.type');
                     switch (schemaType) {
                       case APIType.string:
-                        final Expression? asString = refer('paramToString')([
-                          expression
-                        ]);
+                        final Expression? asString = refer('paramToString')([expression]);
                         if (param.schema!.format == 'uuid') {
                           assert(paramType == _apiUuid);
-                          return _apiUuid.newInstanceNamed(
-                              'parse', [asString!]);
+                          return _apiUuid.newInstanceNamed('parse', [asString!]);
                         } else if (paramType != _typeString) {
                           //throw StateError('Unsupported paramType for string $paramType');
-                          return _apiUuid.newInstanceNamed(
-                              'parse', [asString!]);
+                          return _apiUuid.newInstanceNamed('parse', [asString!]);
                         }
                         return asString;
                       case APIType.number:
@@ -257,41 +214,32 @@ class OpenApiLibraryGenerator {
                       case APIType.boolean:
                         return refer('paramToBool')([expression]);
                       case APIType.array:
-                      //checkState(param.schema!.items!.type == APIType.string);
-                        if (param.schema!.items!.enumerated != null && param
-                            .schema!.items!.enumerated!.isNotEmpty) {
-                          final paramEnumType = (paramType as TypeReference)
-                              .types.first;
+                        //checkState(param.schema!.items!.type == APIType.string);
+                        if (param.schema!.items!.enumerated != null && param.schema!.items!.enumerated!.isNotEmpty) {
+                          final paramEnumType = (paramType as TypeReference).types.first;
                           return expression
                               .property('map')([
-                            Method(
-                                  (mb) =>
-                              mb
-                                ..lambda = true
-                                ..requiredParameters.add(
-                                    Parameter((pb) => pb..name = 'e'))
-                                ..body =
-                                    refer(paramEnumType.symbol! + 'Ext')
-                                        .property('fromName')([refer('e')])
-                                        .code,
-                            ).closure
-                          ])
+                                Method(
+                                  (mb) => mb
+                                    ..lambda = true
+                                    ..requiredParameters.add(Parameter((pb) => pb..name = 'e'))
+                                    ..body =
+                                        refer(paramEnumType.symbol! + 'Ext').property('fromName')([refer('e')]).code,
+                                ).closure
+                              ])
                               .property('toList')([]);
                         } else {
-                          final paramEnumType = (paramType as TypeReference)
-                              .types.first;
+                          final paramEnumType = (paramType as TypeReference).types.first;
                           return refer('paramToInt')([expression]);
                           return expression
                               .property('map')([
-                            Method(
-                                  (mb) =>
-                              mb
-                                ..lambda = true
-                                ..requiredParameters.add(
-                                    Parameter((pb) => pb..name = 'e'))
-                                ..body = refer('e').code,
-                            ).closure
-                          ])
+                                Method(
+                                  (mb) => mb
+                                    ..lambda = true
+                                    ..requiredParameters.add(Parameter((pb) => pb..name = 'e'))
+                                    ..body = refer('e').code,
+                                ).closure
+                              ])
                               .property('toList')([]);
                         }
                         return expression;
@@ -302,26 +250,21 @@ class OpenApiLibraryGenerator {
                     }
                   };
                   final decodeParameter = (Expression? expression) {
-                    return refer(
-                        param.isRequired ? 'paramRequired' : 'paramOpt')([], {
+                    return refer(param.isRequired ? 'paramRequired' : 'paramOpt')([], {
                       'name': literalString(param.name!),
                       'value': expression!,
                       'decode': Method((mb) {
-                        final paramFrom = decodeParameterFrom(
-                            param, refer('value'));
+                        final paramFrom = decodeParameterFrom(param, refer('value'));
                         mb
                           ..lambda = true
-                          ..requiredParameters.add(
-                              Parameter((pb) => pb..name = 'value'))
+                          ..requiredParameters.add(Parameter((pb) => pb..name = 'value'))
                           ..body = paramFrom?.code;
                       }).closure,
                     });
                   };
-                  final paramLocation = ArgumentError.checkNotNull(
-                      param.location);
+                  final paramLocation = ArgumentError.checkNotNull(param.location);
                   final paramName = ArgumentError.checkNotNull(param.name);
-                  routerParamsNamed[paramNameCamelCase] = decodeParameter(
-                      _readFromRequest(paramLocation, paramName));
+                  routerParamsNamed[paramNameCamelCase] = decodeParameter(_readFromRequest(paramLocation, paramName));
                 }
 
                 final body = operation.value!.requestBody;
@@ -329,10 +272,8 @@ class OpenApiLibraryGenerator {
                   final entry = body.content!.entries.first;
 
                   if (body.content!.length > 1) {
-                    _logger.warning(
-                        'Right now we only support one request body, '
-                            'but found: ${body.content!
-                            .keys}, only using $entry');
+                    _logger.warning('Right now we only support one request body, '
+                        'but found: ${body.content!.keys}, only using $entry');
                   }
 
                   Map.fromEntries([entry]).forEach((key, reqBody) {
@@ -356,113 +297,64 @@ class OpenApiLibraryGenerator {
               clientCode.add(Code('final queryParams = <String, dynamic>{};'));
 
               final allParameters = [
-                ...?operation.value?.parameters?.where((element) =>
-                element?.location == APIParameterLocation.query),
-                ...?path.value?.parameters?.where((element) =>
-                element?.location == APIParameterLocation.query),
+                ...?operation.value?.parameters?.where((element) => element?.location == APIParameterLocation.query),
+                ...?path.value?.parameters?.where((element) => element?.location == APIParameterLocation.query),
               ];
               for (final element in allParameters) {
                 if (element?.schema?.type == APIType.array) {
                   clientCode.add(Code(
-                      '''if (${element!.name!
-                          .camelCase} != null) queryParams['${element
-                          .name}'] = ${element.name!.camelCase}.join(',');'''));
+                      '''if (${element!.name!.camelCase} != null) queryParams['${element.name}'] = ${element.name!.camelCase}.join(',');'''));
                 } else if (element?.schema?.enumerated != null) {
                   clientCode.add(Code(
-                      '''if (${element!.name!
-                          .camelCase} != null) queryParams['${element
-                          .name}'] = ${element.name!.camelCase}.name;'''));
+                      '''if (${element!.name!.camelCase} != null) queryParams['${element.name}'] = ${element.name!.camelCase}.name;'''));
                 } else {
                   clientCode.add(Code(
-                      '''if (${element!.name!
-                          .camelCase} != null) queryParams['${element
-                          .name}'] = ${element.name!
-                          .camelCase}.toString();'''));
+                      '''if (${element!.name!.camelCase} != null) queryParams['${element.name}'] = ${element.name!.camelCase}.toString();'''));
                 }
               }
 
-              clientCode.add(Code('''
-    final uri = baseUri.replace(
-        queryParameters: queryParams, 
-        path: baseUri.path + '${_convertPathParamsToCamelCase(
-                  path.key.replaceAll('{', '\${'))}');
-  '''));
+              clientCode.add(Code('''final uri = baseUri.replace(queryParameters: queryParams, path: baseUri.path + '${_convertPathParamsToCamelCase(path.key.replaceAll('{', '\${'))}');'''));
 
               if (successResponseBodyType == _dioResponseBody) {
                 clientCode.add(
                   Code(
-                      'final response = await dio.${operation
-                          .key}Uri<${successResponseBodyType!
-                          .symbol}>(uri${operation.value?.requestBody != null
-                          ? ', data: body'
-                          : ''}, options: Options(responseType: ResponseType.stream));'),
+                      'final response = await dio.${operation.key}Uri<${successResponseBodyType!.symbol}>(uri${operation.value?.requestBody != null ? ', data: body' : ''}, options: Options(responseType: ResponseType.stream));'),
                 );
               } else if (successResponseBodyType?.symbol == 'List') {
                 clientCode.add(
                   Code(
-                      'final response = await dio.${operation
-                          .key}Uri<${successResponseBodyType != null
-                          ? 'List<dynamic>'
-                          : 'void'}>(uri${operation.value?.requestBody != null
-                          ? ', data: body'
-                          : ''});'),
+                      'final response = await dio.${operation.key}Uri<${successResponseBodyType != null ? 'List<dynamic>' : 'void'}>(uri${operation.value?.requestBody != null ? ', data: body' : ''});'),
                 );
-              } else
-              if (operation.value!.requestBody?.content?.keys.firstOrNull ==
-                  'multipart/form-data') {
+              } else if (operation.value!.requestBody?.content?.keys.firstOrNull == 'multipart/form-data') {
                 final body = '''FormData.fromMap(<String, dynamic>{
-                ${operation.value!.requestBody!.content!.values.first!.schema!
-                    .properties!.entries.map((element) => '\'${element
-                    .key}\': ${element.value!.type == APIType.object
-                    ? 'MultipartFile.fromString(jsonEncode(' + element.key +
-                    '.toJson()), filename: \'' + element.key +
-                    '.json\', contentType: MediaType(\'application\', \'json\'))'
-                    : element.key}').join(',')}
+                ${operation.value!.requestBody!.content!.values.first!.schema!.properties!.entries.map((element) => '\'${element.key}\': ${element.value!.type == APIType.object ? 'MultipartFile.fromString(jsonEncode(' + element.key + '.toJson()), filename: \'' + element.key + '.json\', contentType: MediaType(\'application\', \'json\'))' : element.key}').join(',')}
       })''';
                 clientCode.add(
                   Code(
-                      'final response = await dio.${operation
-                          .key}Uri<${successResponseBodyType != null
-                          ? 'Map<String, dynamic>'
-                          : 'void'}>(uri${operation.value?.requestBody != null
-                          ? ', data: $body'
-                          : ''});'),
+                      'final response = await dio.${operation.key}Uri<${successResponseBodyType != null ? 'Map<String, dynamic>' : 'void'}>(uri${operation.value?.requestBody != null ? ', data: $body' : ''});'),
                 );
               } else {
                 // TODO list all primitives?
                 if (successResponseBodyType == _typeString) {
                   clientCode.add(
                     Code(
-                        'final response = await dio.${operation
-                            .key}Uri<${successResponseBodyType!
-                            .symbol}>(uri${operation.value?.requestBody != null
-                            ? ', data: body'
-                            : ''});'),
+                        'final response = await dio.${operation.key}Uri<${successResponseBodyType!.symbol}>(uri${operation.value?.requestBody != null ? ', data: body' : ''});'),
                   );
                 } else {
                   clientCode.add(
                     Code(
-                        'final response = await dio.${operation
-                            .key}Uri<${successResponseBodyType != null
-                            ? 'Map<String, dynamic>'
-                            : 'void'}>(uri${operation.value?.requestBody != null
-                            ? ', data: body'
-                            : ''});'),
+                        'final response = await dio.${operation.key}Uri<${successResponseBodyType != null ? 'Map<String, dynamic>' : 'void'}>(uri${operation.value?.requestBody != null ? ', data: body' : ''});'),
                   );
                 }
               }
-              if (successResponseBodyType == null ||
-                  successResponseBodyType == _dioResponseBody) {
+              if (successResponseBodyType == null || successResponseBodyType == _dioResponseBody) {
                 clientCode.add(Code('return response;'));
               } else if (successResponseBodyType.symbol == 'List') {
-                final listType = (successResponseBodyType as TypeReference)
-                    .types.last;
+                final listType = (successResponseBodyType as TypeReference).types.last;
                 clientCode.add(
                   Code(
-                      '''final parsed = response.data!.map((dynamic e) => ${listType
-                          .symbol}.fromJson(e as Map<String, dynamic>)).toList();
-                  return Response<${successResponseBodyType.symbol}<${listType
-                          .symbol}>>(
+                      '''final parsed = response.data!.map((dynamic e) => ${listType.symbol}.fromJson(e as Map<String, dynamic>)).toList();
+                  return Response<${successResponseBodyType.symbol}<${listType.symbol}>>(
                     data: parsed,
                     headers: response.headers,
                     requestOptions: response.requestOptions,
@@ -476,10 +368,7 @@ class OpenApiLibraryGenerator {
               } else {
                 clientCode.add(
                   Code(
-                      '''final parsed = ${successResponseBodyType == _typeString
-                          ? 'response.data!'
-                          : '${successResponseBodyType
-                          .symbol}.fromJson(response.data!)'};
+                      '''final parsed = ${successResponseBodyType == _typeString ? 'response.data!' : '${successResponseBodyType.symbol}.fromJson(response.data!)'};
                   return Response<${successResponseBodyType.symbol}>(
                     data: parsed,
                     headers: response.headers,
@@ -505,54 +394,46 @@ class OpenApiLibraryGenerator {
     return lb.build();
   }
 
+  Expression _readFromRequest(APIParameterLocation location, String name) {
+    switch (location) {
+      case APIParameterLocation.query:
+        return refer('request').property('queryParameter')([literalString(name)]);
+      case APIParameterLocation.header:
+        return refer('request').property('headerParameter')([literalString(name)]);
+      case APIParameterLocation.path:
+        return refer('request').property('pathParameter')([literalString(name)]);
+      case APIParameterLocation.cookie:
+        return refer('request').property('cookieParameter')([literalString(name)]);
+    }
+    // throw StateError('Invalid location: $location');
+  }
+
   String _convertPathParamsToCamelCase(String path) {
     final regex = RegExp(r'{(.*?)}');
     return path.replaceAllMapped(regex, (match) {
       final param = match.group(1);
       if (param != null) {
-        return '{${param.snakeCase.camelCase}}';
+        return '{${param.camelCase}}';
       }
       return match.group(0)!;
     });
   }
 
-  Expression _readFromRequest(APIParameterLocation location, String name) {
-    switch (location) {
-      case APIParameterLocation.query:
-        return refer('request').property('queryParameter')(
-            [literalString(name)]);
-      case APIParameterLocation.header:
-        return refer('request').property('headerParameter')(
-            [literalString(name)]);
-      case APIParameterLocation.path:
-        return refer('request').property('pathParameter')(
-            [literalString(name)]);
-      case APIParameterLocation.cookie:
-        return refer('request').property('cookieParameter')(
-            [literalString(name)]);
-    }
-    // throw StateError('Invalid location: $location');
-  }
-
-  void _createRequestBody(OpenApiContentType contentType, APIMediaType reqBody,
-      bool isRequired, String operationName,
-      MethodBuilder mb, List<Expression?> routerParams,
-      MethodBuilder clientMethod, List<Code> clientCode) {
+  void _createRequestBody(OpenApiContentType contentType, APIMediaType reqBody, bool isRequired, String operationName,
+      MethodBuilder mb, List<Expression?> routerParams, MethodBuilder clientMethod, List<Code> clientCode) {
     _logger.finer('reqBody.schema: ${reqBody.schema}');
 
     void _addRequestBody(Reference bodyType, Expression? decodeBody) {
       mb.addDartDoc(reqBody.schema!.description, prefix: '[body]:');
       if (isRequired) {
         mb.requiredParameters.add(
-          Parameter((pb) =>
-          pb
+          Parameter((pb) => pb
             ..name = 'body'
             ..type = bodyType),
         );
       } else {
         mb.optionalParameters.add(
-          Parameter((pb) =>
-          pb
+          Parameter((pb) => pb
             ..name = 'body'
             ..required = false
             ..type = bodyType.asNullable(true)),
@@ -560,13 +441,11 @@ class OpenApiLibraryGenerator {
       }
       clientMethod.addDartDoc(reqBody.schema!.description, prefix: '[body]:');
       if (isRequired) {
-        clientMethod.requiredParameters.add(Parameter((pb) =>
-        pb
+        clientMethod.requiredParameters.add(Parameter((pb) => pb
           ..name = 'body'
           ..type = bodyType));
       } else {
-        clientMethod.optionalParameters.add(Parameter((pb) =>
-        pb
+        clientMethod.optionalParameters.add(Parameter((pb) => pb
           ..name = 'body'
           ..required = false
           ..type = bodyType.asNullable(true)));
@@ -582,49 +461,36 @@ class OpenApiLibraryGenerator {
     if (contentType.matches(OpenApiContentType.textPlain)) {
       _addRequestBody(
         _typeString,
-        refer('request')
-            .property('readBodyString')([])
-            .awaited,
+        refer('request').property('readBodyString')([]).awaited,
       );
     } else if (contentType.matches(OpenApiContentType.octetStream)) {
       _addRequestBody(
         _toDartType(operationName, reqBody.schema!),
-        refer('request')
-            .property('readBodyBytes')([])
-            .awaited,
+        refer('request').property('readBodyBytes')([]).awaited,
       );
     } else if (contentType.contentType == 'multipart/form-data') {
       for (final property in reqBody.schema!.properties!.entries) {
-        mb.addDartDoc(
-            reqBody.schema!.description, prefix: '[${property.key}]:');
+        mb.addDartDoc(reqBody.schema!.description, prefix: '[${property.key}]:');
         mb.requiredParameters.add(
-          Parameter((pb) =>
-          pb
+          Parameter((pb) => pb
             ..name = property.key
             ..type = _toDartType(operationName, property.value!)),
         );
-        clientMethod.addDartDoc(
-            reqBody.schema!.description, prefix: '[${property.key}]:');
-        clientMethod.requiredParameters.add(Parameter((pb) =>
-        pb
+        clientMethod.addDartDoc(reqBody.schema!.description, prefix: '[${property.key}]:');
+        clientMethod.requiredParameters.add(Parameter((pb) => pb
           ..name = property.key
           ..type = _toDartType(operationName, property.value!)));
 
         //routerParams.add(decodeBody);
       }
     } else {
-      final reference = _schemaReference(
-          '${operationName.pascalCase}Schema', reqBody.schema!);
+      final reference = _schemaReference('${operationName.pascalCase}Schema', reqBody.schema!);
 
       final mapExpression = contentType.matches(OpenApiContentType.json)
-          ? refer('request')
-          .property('readJsonBody')([])
-          .awaited
+          ? refer('request').property('readJsonBody')([]).awaited
           : (contentType.matches(OpenApiContentType.urlencoded)
-          ? refer('request')
-          .property('readUrlEncodedBodyFlat')([])
-          .awaited
-          : literalConstMap({}, refer('String'), refer('dynamic')));
+              ? refer('request').property('readUrlEncodedBodyFlat')([]).awaited
+              : literalConstMap({}, refer('String'), refer('dynamic')));
       _addRequestBody(
           reference,
           reference.property('fromJson')(
@@ -652,27 +518,24 @@ class OpenApiLibraryGenerator {
   Reference _schemaReference(String key, APISchemaObject schemaObject) {
     _logger.finer('Looking up ${schemaObject.referenceURI}');
     final uri = schemaObject.referenceURI;
-    final componentName = _componentNameFromReferenceUri(uri) ??
-        _classNameForComponent(key);
+    final componentName = _componentNameFromReferenceUri(uri) ?? _classNameForComponent(key);
 
-    final found = createdSchema.values.firstWhereOrNull((element) =>
-    element.symbol == componentName);
+    final found = createdSchema.values.firstWhereOrNull((element) => element.symbol == componentName);
     if (found != null) {
       _logger.finest('We found it.');
       return found;
     }
 
     final reference = createdSchema.putIfAbsent(schemaObject, () {
-      _logger.finer(
-          'Creating schema class. for ${schemaObject.referenceURI} / $key');
+      _logger.finer('Creating schema class. for ${schemaObject.referenceURI} / $key');
       if (schemaObject.enumerated?.isNotEmpty == true) {
         final e = _createEnum(componentName, schemaObject.enumerated!);
         return e;
       }
       final c = _createSchemaClass(componentName, schemaObject);
       // TODO figure out a better way to not add all schema classes
-      if (schemaObject.properties?.values.any((p0) => p0!.format == 'binary') ==
-          true) {} else {
+      if (schemaObject.properties?.values.any((p0) => p0!.format == 'binary') == true) {
+      } else {
         lb.body.add(c);
       }
 
@@ -707,8 +570,7 @@ class OpenApiLibraryGenerator {
       }
     }
 
-    final fields = properties.map((key, e) =>
-        MapEntry(key, Field((fb) {
+    final fields = properties.map((key, e) => MapEntry(key, Field((fb) {
           final fieldType = _toDartType('$className${key.pascalCase}', e!);
           fb
             ..addDartDoc(e.description)
@@ -716,12 +578,10 @@ class OpenApiLibraryGenerator {
             ..annotations.addAll(override.contains(key) ? [_override] : [])
             ..name = key.camelCase
             ..modifier = FieldModifier.final$
-            ..type = fieldType.asNullable(
-                !required.contains(key) && e.defaultValue == null);
+            ..type = fieldType.asNullable(!required.contains(key) && e.defaultValue == null);
           if (fieldType == _apiUuid) {
             fb.annotations.add(_apiUuidNullJsonConverter([]));
-          } else if (fieldType is TypeReference &&
-              fieldType.types.firstOrNull == _apiUuid) {
+          } else if (fieldType is TypeReference && fieldType.types.firstOrNull == _apiUuid) {
             fb.annotations.add(_listApiUuidNullJsonConverter([]));
           }
         })));
@@ -735,14 +595,11 @@ class OpenApiLibraryGenerator {
 
     if (false &&
         api.components!.schemas!.entries.any(
-                (element) =>
-            element.value!.allOf?.any((el) =>
-                el!.referenceURI.toString().contains(className)) == true)) {
+            (element) => element.value!.allOf?.any((el) => el!.referenceURI.toString().contains(className)) == true)) {
       return Mixin((mixing) {
         mixing
           ..name = className
-          ..methods.addAll(fields.values.map((e) =>
-              Method((m) {
+          ..methods.addAll(fields.values.map((e) => Method((m) {
                 m
                   ..type = MethodType.getter
                   ..returns = e.type?.asNullable(true)
@@ -753,13 +610,10 @@ class OpenApiLibraryGenerator {
     }
 
     final c = Class((cb) {
-      Expression? toJsonExpression = refer('_\$${className}ToJson')(
-          [refer('this')]);
-      Expression? fromJsonExpression = refer('_\$${className}FromJson').call(
-          [refer('jsonMap')]);
+      Expression? toJsonExpression = refer('_\$${className}ToJson')([refer('this')]);
+      Expression? fromJsonExpression = refer('_\$${className}FromJson').call([refer('jsonMap')]);
 
-      if (obj.additionalPropertyPolicy ==
-          APISchemaAdditionalPropertyPolicy.freeForm) {
+      if (obj.additionalPropertyPolicy == APISchemaAdditionalPropertyPolicy.freeForm) {
         /*toJsonExpression =
             refer('Map').property('from')([refer('_additionalProperties')]).cascade('addAll')([toJsonExpression]);
         fromJsonExpression = fromJsonExpression.cascade('_additionalProperties').property('addEntries')([
@@ -786,58 +640,46 @@ class OpenApiLibraryGenerator {
         ..annotations.add(freezed)
         ..name = className
         ..mixins.add(refer('_\$$className'))
-      //..mixins.addAll(implements)
+        //..mixins.addAll(implements)
         ..docs.addDartDoc(obj.description)
         ..constructors.add(
           Constructor(
-                (cb) =>
-            cb
+            (cb) => cb
               ..factory = true
               ..redirect = refer('_$className')
-              ..optionalParameters.addAll(fields.entries.map((f) =>
-                  Parameter((pb) =>
-                  pb
+              ..optionalParameters.addAll(fields.entries.map((f) => Parameter((pb) => pb
 //            ..docs.addAll(f.docs)
-                    ..name = f.value.name
-                    ..annotations.add(jsonKey([], {'name': literalString(
-                        f.value.name)}))
-                    ..let((that) {
-                      final fieldType = _toDartType(
-                          '$className${f.key.pascalCase}', properties[f.key]!);
-                      if (fieldType == _apiUuid) {
-                        that.annotations.add(_apiUuidNullJsonConverter([]));
-                      } else if (fieldType is TypeReference &&
-                          fieldType.types.firstOrNull == _apiUuid) {
-                        that.annotations.add(_listApiUuidNullJsonConverter([]));
-                      }
-                      return that;
-                    })
-                    ..asRequired(this, required.contains(f.key))
-                  // TODO add default values
-                  //..defaultTo = (properties[f.key]?.defaultValue as Object?)?.let((dynamic it) => literal(it)).code
-                    ..named = true
-                    ..type = _toDartType('$className${f.key.pascalCase}',
-                        properties[f.key]!).asNullable(true)
-                    ..toThis = false)))
+                ..name = f.value.name
+                ..annotations.add(jsonKey([], {'name': literalString(f.value.name)}))
+                ..let((that) {
+                  final fieldType = _toDartType('$className${f.key.pascalCase}', properties[f.key]!);
+                  if (fieldType == _apiUuid) {
+                    that.annotations.add(_apiUuidNullJsonConverter([]));
+                  } else if (fieldType is TypeReference && fieldType.types.firstOrNull == _apiUuid) {
+                    that.annotations.add(_listApiUuidNullJsonConverter([]));
+                  }
+                  return that;
+                })
+                ..asRequired(this, required.contains(f.key))
+                // TODO add default values
+                //..defaultTo = (properties[f.key]?.defaultValue as Object?)?.let((dynamic it) => literal(it)).code
+                ..named = true
+                ..type = _toDartType('$className${f.key.pascalCase}', properties[f.key]!).asNullable(true)
+                ..toThis = false)))
               ..initializers.addAll(useNullSafetySyntax
                   ? []
-                  : required.map((e) =>
-              refer('assert')([refer(fields[e]!.name).notEqualTo(literalNull)])
-                  .code)),
+                  : required.map((e) => refer('assert')([refer(fields[e]!.name).notEqualTo(literalNull)]).code)),
           ),
         )
         ..let((that) {
-          if (fields.entries.any((f) =>
-          properties[f.key]?.format == 'binary')) {
+          if (fields.entries.any((f) => properties[f.key]?.format == 'binary')) {
             return that;
           } else {
             return that
-              ..constructors.add(Constructor((cb) =>
-              cb
+              ..constructors.add(Constructor((cb) => cb
                 ..name = 'fromJson'
                 ..factory = true
-                ..requiredParameters.add(Parameter((pb) =>
-                pb
+                ..requiredParameters.add(Parameter((pb) => pb
                   ..name = 'jsonMap'
                   ..type = refer('Map<String, dynamic>')))
                 ..lambda = true
@@ -854,14 +696,13 @@ class OpenApiLibraryGenerator {
         name: name,
         values: values!
             .map(
-              (dynamic e) =>
-              EnumValueSpec(
+              (dynamic e) => EnumValueSpec(
                 annotations: [
                   jsonValue([literalString(e.toString())])
                 ],
                 name: e.toString(),
               ),
-        )
+            )
             .toList(),
       ));
       return refer(name);
@@ -902,18 +743,12 @@ class OpenApiLibraryGenerator {
         final type = _toDartType(parent, schema.items!);
         return _referType('List', generics: [type]);
       case APIType.object:
-        if (schema.additionalPropertyPolicy ==
-            APISchemaAdditionalPropertyPolicy.freeForm) {
+        if (schema.additionalPropertyPolicy == APISchemaAdditionalPropertyPolicy.freeForm) {
           // TODO instead there should be an additionalProperties field instead
-          return _referType(
-              'Map', generics: [refer('String'), refer('dynamic')]);
-        } else if (schema.additionalPropertyPolicy ==
-            APISchemaAdditionalPropertyPolicy.restricted &&
+          return _referType('Map', generics: [refer('String'), refer('dynamic')]);
+        } else if (schema.additionalPropertyPolicy == APISchemaAdditionalPropertyPolicy.restricted &&
             schema.additionalPropertySchema != null) {
-          return _referType('Map', generics: [
-            refer('String'),
-            _toDartType(parent, schema.additionalPropertySchema!)
-          ]);
+          return _referType('Map', generics: [refer('String'), _toDartType(parent, schema.additionalPropertySchema!)]);
         }
         return _schemaReference(parent, schema);
 //        return refer('dynamic');
@@ -943,8 +778,7 @@ class EnumSpec extends Spec {
     ctx.write('static final Map<String, $name> _names = ');
     visitor.visitSpec(
         literalMap(
-            Map.fromEntries(values!.map((e) => MapEntry(
-                literalString(e.name!), refer(name!).property(e.name!))))),
+            Map.fromEntries(values!.map((e) => MapEntry(literalString(e.name!), refer(name!).property(e.name!))))),
         context);
     ctx.write(';');
     ctx.write('static $name fromName(String name) => _names[name] ??'
@@ -981,8 +815,7 @@ class OpenApiCodeBuilderUtils {
 
   static APIDocument loadApiFromYaml(String yamlSource) {
     final decoded = _loadYaml(yamlSource)!;
-    final api = APIDocument.fromMap(
-        Map<String, dynamic>.from(decoded.cast<String, dynamic>()));
+    final api = APIDocument.fromMap(Map<String, dynamic>.from(decoded.cast<String, dynamic>()));
     return api;
   }
 
@@ -993,18 +826,16 @@ class OpenApiCodeBuilderUtils {
       orderDirectives: orderDirectives,
       useNullSafetySyntax: useNullSafetySyntax,
     );
-    final libraryOutput = DartFormatter().format(
-        '// GENERATED CODE - DO NOT MODIFY BY HAND\n\n\n'
-            '// ignore_for_file: prefer_initializing_formals, unnecessary_brace_in_string_interps\n\n'
-            '${library.accept(emitter)}\n\n'
-            'T _throwStateError<T>(String message) => throw StateError(message);\n\n');
+    final libraryOutput = DartFormatter().format('// GENERATED CODE - DO NOT MODIFY BY HAND\n\n\n'
+        '// ignore_for_file: prefer_initializing_formals, unnecessary_brace_in_string_interps\n\n'
+        '${library.accept(emitter)}\n\n'
+        'T _throwStateError<T>(String message) => throw StateError(message);\n\n');
     return libraryOutput;
   }
 }
 
 class OpenApiCodeBuilder extends Builder {
-  OpenApiCodeBuilder(
-      {this.orderDirectives = false, required this.useNullSafetySyntax});
+  OpenApiCodeBuilder({this.orderDirectives = false, required this.useNullSafetySyntax});
 
   final bool orderDirectives;
   final bool useNullSafetySyntax;
@@ -1018,25 +849,17 @@ class OpenApiCodeBuilder extends Builder {
     final outputId = inputId.changeExtension('.dart');
     final source = await buildStep.readAsString(inputId);
     checkArgument(inputId.pathSegments.last.endsWith('.openapi.yaml'));
-    final inputIdBasename = inputId.pathSegments.last.replaceAll(
-        '.openapi.yaml', '');
+    final inputIdBasename = inputId.pathSegments.last.replaceAll('.openapi.yaml', '');
     OpenApiCodeBuilderUtils.loadApiFromYaml(source);
     final api = OpenApiCodeBuilderUtils.loadApiFromYaml(source);
 
-    final baseName = api.info!.extensions['x-dart-name'] as String? ??
-        inputIdBasename.pascalCase;
+    final baseName = api.info!.extensions['x-dart-name'] as String? ?? inputIdBasename.pascalCase;
 
     final l = OpenApiLibraryGenerator(
       api,
       baseName,
-      AssetId(outputId.package, outputId.path)
-          .changeExtension('.g.dart')
-          .pathSegments
-          .last,
-      AssetId(outputId.package, outputId.path)
-          .changeExtension('.freezed.dart')
-          .pathSegments
-          .last,
+      AssetId(outputId.package, outputId.path).changeExtension('.g.dart').pathSegments.last,
+      AssetId(outputId.package, outputId.path).changeExtension('.freezed.dart').pathSegments.last,
       useNullSafetySyntax: useNullSafetySyntax,
     ).generate();
 
@@ -1056,27 +879,20 @@ class OpenApiCodeBuilder extends Builder {
   }
 
   @override
-  Map<String, List<String>> get buildExtensions =>
-      {
+  Map<String, List<String>> get buildExtensions => {
         '.openapi.yaml': ['.openapi.dart']
       };
 }
 
-TypeReference _referType(String name,
-    {String? url, List<Reference>? generics}) =>
-    TypeReference((trb) =>
-    trb
-      ..symbol = name
-      ..url = url
-      ..types.addAll(generics!));
+TypeReference _referType(String name, {String? url, List<Reference>? generics}) => TypeReference((trb) => trb
+  ..symbol = name
+  ..url = url
+  ..types.addAll(generics!));
 
 extension on Reference {
   Reference addGenerics(Reference type) {
-    final baseTypes = this is TypeReference
-        ? (this as TypeReference).types
-        : null;
-    return TypeReference((trb) =>
-    trb
+    final baseTypes = this is TypeReference ? (this as TypeReference).types : null;
+    return TypeReference((trb) => trb
       ..symbol = symbol
       ..url = url
       ..types.addAll([...?baseTypes, type]));
@@ -1086,8 +902,7 @@ extension on Reference {
     if (!isNullable) {
       return this;
     }
-    return ((type as TypeReference).toBuilder()
-      ..isNullable = true).build();
+    return ((type as TypeReference).toBuilder()..isNullable = true).build();
   }
 }
 
@@ -1106,14 +921,12 @@ extension on ListBuilder<String> {
 
 extension on FieldBuilder {
   /// adds the given helpText as `docs` if it is not null.
-  void addDartDoc(String? helpText, {String? prefix}) =>
-      docs.addDartDoc(helpText, prefix: prefix);
+  void addDartDoc(String? helpText, {String? prefix}) => docs.addDartDoc(helpText, prefix: prefix);
 }
 
 extension on MethodBuilder {
   /// adds the given helpText as `docs` if it is not null.
-  void addDartDoc(String? helpText, {String? prefix}) =>
-      docs.addDartDoc(helpText, prefix: prefix);
+  void addDartDoc(String? helpText, {String? prefix}) => docs.addDartDoc(helpText, prefix: prefix);
 }
 
 extension on ParameterBuilder {
@@ -1132,6 +945,5 @@ extension DynamicExt<T> on dynamic {
 
 extension ObjectExt<T> on T {
   T? takeIf(bool Function(T that) predicate) => predicate(this) ? this : null;
-
   R let<R>(R Function(T that) op) => op(this);
 }


### PR DESCRIPTION
@jonasbark 

The issue:
https://github.com/jonasbark/openapi_freezed_dio_builder/issues/7

The URL parameters with underscores are not being correctly converted to camel case in the generated code. This issue occurs when using the OpenAPI YAML file with the following configuration:

<img width="433" alt="image" src="https://github.com/jonasbark/openapi_freezed_dio_builder/assets/607963/f0d1dd61-37fc-491d-a074-13f4eb8cb91c">


Generated Code Example
The generated code does not properly convert the student_id parameter to camel case (studentId):

<img width="539" alt="image" src="https://github.com/jonasbark/openapi_freezed_dio_builder/assets/607963/ba33c8fb-b233-432a-a3e1-8be0fd8c920a">

Should be `/${studentId}/`

Expected Behavior
The parameter student_id should be correctly converted to camel case (studentId) in the generated code, ensuring consistency and correct functionality.


Source codes:
`
/v1/students/{student_id}/courses/reading:
  get:
    operationId: getV1StudentsStudentIdCourses
    parameters:
    - name: student_id
      in: path
      required: true
      schema:
        type: string
        
Future<Response<ApiV1EntitiesBasicCourse>>
    getV1StudentsStudentIdCourses(
        {required String studentId}) async {
  final queryParams = <String, dynamic>{};
  final uri = baseUri.replace(
      queryParameters: queryParams,
      path: baseUri.path +
          '/v1/students/${student_id}/courses');
  final response = await dio.getUri<Map<String, dynamic>>(uri);
  final parsed = ApiLearningV1EntitiesBasicCourse.fromJson(response.data!);
  return Response<ApiLearningV1EntitiesBasicCourse>(
    data: parsed,
    headers: response.headers,
    requestOptions: response.requestOptions,
    isRedirect: response.isRedirect,
    statusCode: response.statusCode,
    redirects: response.redirects,
    extra: response.extra,
  );
}
`
        